### PR TITLE
Removed menu as it displays at smaller viewports

### DIFF
--- a/app/views/patterns/macro/header.html
+++ b/app/views/patterns/macro/header.html
@@ -24,7 +24,6 @@ cookie
     {% if proposition %}
     <div class="header-proposition">
       <div class="content">
-        <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
         <nav id="proposition-menu">
         <ul class="service-info">
           <li><a href="/" id="proposition-name">{{serviceName}}</a></li>


### PR DESCRIPTION
There is no need for the menu link as it hides the sign-out link on smaller screens.