### PR TITLE
Use a 'real' redirect to take people to the Github pages site for the Design System

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -3,7 +3,7 @@ var router = express.Router()
 
 // Route index page
 router.get('/', function (req, res) {
-  res.render('govuk-template.html')
+  res.redirect(301, "http://hmrc.github.io/assets-frontend/")
 })
 
 // add your routes here


### PR DESCRIPTION
I've Replaced the default route with an http 301 redirect to the Github pages site.

Feels free to delete the PR if it's not the behaviour you want.